### PR TITLE
Added support for int types in Insert and float32 in QueryStruct

### DIFF
--- a/mysql/Fields.go
+++ b/mysql/Fields.go
@@ -1,186 +1,222 @@
 package mysql
 
 import (
-    "fmt"
-    "strconv"
-    "time"
-    
-    l "log/slog"
+	"fmt"
+	"strconv"
+	"time"
+
+	l "log/slog"
 )
 
 // The Database returns a map of []Records and each Record is a map of Fields.
 // This provides a way to get the Field from the Record.
 
 type Field struct {
-    Value any
+	Value any
 }
 
 func (F Field) AsString() string {
-    
-    if F.Value == nil {
-        return ""
-    }
-    
-    switch v := F.Value.(type) {
-    case int32:
-    
-    case int64:
-        // Convert to a String
-        return strconv.FormatInt(int64(F.Value.(int64)), 10)
-    case float64:
-        // fmt.Printf("Float64: %v\n", val)
-        // Arry of Bytes.
-    case []uint8:
-        b, _ := F.Value.([]byte)
-        return string(b)
-    case string:
-        return F.Value.(string)
-    
-    default:
-        l.Error("Can not convert type: '" + fmt.Sprintf("%T", v) + "' to a String")
-    }
-    
-    return F.Value.(string)
+
+	if F.Value == nil {
+		return ""
+	}
+
+	switch v := F.Value.(type) {
+	case int32:
+
+	case int64:
+		// Convert to a String
+		return strconv.FormatInt(int64(F.Value.(int64)), 10)
+	case float64:
+		// fmt.Printf("Float64: %v\n", val)
+		// Arry of Bytes.
+	case []uint8:
+		b, _ := F.Value.([]byte)
+		return string(b)
+	case string:
+		return F.Value.(string)
+
+	default:
+		l.Error("Can not convert type: '" + fmt.Sprintf("%T", v) + "' to a String")
+	}
+
+	return F.Value.(string)
 }
 
 func (F Field) AsFloat() float64 {
-    
-    if F.Value == nil {
-        return 0
-    }
-    
-    return float64(F.Value.(float64))
+
+	if F.Value == nil {
+		return 0
+	}
+
+	switch v := F.Value.(type) {
+	case int:
+		return float64(F.Value.(int))
+	case int8:
+		return float64(F.Value.(int8))
+	case int16:
+		return float64(F.Value.(int16))
+	case int32:
+		return float64(F.Value.(int32))
+	case int64:
+		return float64(F.Value.(int64))
+	case uint:
+		return float64(F.Value.(uint))
+	case uint8:
+		return float64(F.Value.(uint8))
+	case uint16:
+		return float64(F.Value.(uint16))
+	case uint32:
+		return float64(F.Value.(uint32))
+	case uint64:
+		return float64(F.Value.(uint64))
+	case float32:
+		return float64(F.Value.(float32))
+	case float64:
+		return float64(F.Value.(float64))
+	case string:
+		floatVal, err := strconv.ParseFloat(F.Value.(string), 64)
+		if err != nil {
+			l.With("err", err.Error()).Error(fmt.Sprintf("Cannot convert %T to float64", v))
+			return 0
+		}
+		return floatVal
+	default:
+		l.Error("Can not convert type: '" + fmt.Sprintf("%T", v) + "' to a float64")
+	}
+
+	return float64(F.Value.(float64))
 }
 
 func (F Field) AsDate(d string) time.Time {
-    
-    // https://github.com/go-sql-driver/mysql#timetime-support
-    // This assumes this is OFF.
-    
-    if F.Value == nil {
-        if d != "" {
-            out, _ := time.Parse("2006-01-02 15:04:05", d)
-            return out
-        } else {
-            return time.Now()
-        }
-    }
-    
-    switch v := F.Value.(type) {
-    case time.Time:
-        return F.Value.(time.Time)
-    case string:
-        t, _ := time.Parse("2006-01-02 15:04:05", F.Value.(string))
-        return t
-    default:
-        l.Error("Can not convert type: '" + fmt.Sprintf("%T", v) + "' to a Date")
-        return F.Value.(time.Time)
-    }
-    
+
+	// https://github.com/go-sql-driver/mysql#timetime-support
+	// This assumes this is OFF.
+
+	if F.Value == nil {
+		if d != "" {
+			out, _ := time.Parse("2006-01-02 15:04:05", d)
+			return out
+		} else {
+			return time.Now()
+		}
+	}
+
+	switch v := F.Value.(type) {
+	case time.Time:
+		return F.Value.(time.Time)
+	case string:
+		t, _ := time.Parse("2006-01-02 15:04:05", F.Value.(string))
+		return t
+	default:
+		l.Error("Can not convert type: '" + fmt.Sprintf("%T", v) + "' to a Date")
+		return F.Value.(time.Time)
+	}
+
 }
 
 func (F Field) AsDateEpoch() int64 {
-    
-    if F.Value == nil {
-        return 0
-    }
-    t, _ := time.Parse("2006-01-02 15:04:05", F.Value.(string))
-    
-    return t.Unix()
+
+	if F.Value == nil {
+		return 0
+	}
+	t, _ := time.Parse("2006-01-02 15:04:05", F.Value.(string))
+
+	return t.Unix()
 }
 
 func (F Field) AsInt() int {
-    
-    // TODO:  If there is a NULL in the database.  the Interface is nil.
-    
-    if F.Value == nil {
-        return 0
-    }
-    
-    // This code is needed on each of the fields for flexiblity.  If you need to gt a Field from the database and have in the
-    // code as a different Type.  Most of the time isn't going to be needed. This is (DEFAULT) conversion
-    
-    switch v := F.Value.(type) {
-    case int:
-        // Interface is a Int, so just so the conversion. (DEFAULT)
-        return F.Value.(int)
-    
-    case int32:
-        return int(F.Value.(int32))
-    case int64:
-        return int(F.Value.(int64))
-    case float64:
-        return int(F.Value.(float64))
-    case float32:
-        return int(F.Value.(float32))
-    case []uint8:
-        // Interface Value is an array of Characters Convert a string, then an Int
-        b, _ := F.Value.([]byte)
-        i, _ := strconv.Atoi(string(b))
-        return i
-    case string:
-        i, _ := strconv.Atoi(F.Value.(string))
-        return i
-    
-    default:
-        l.Error("Can not convert type: '" + fmt.Sprintf("%T", v) + "' to a String")
-    }
-    
-    return 0
+
+	// TODO:  If there is a NULL in the database.  the Interface is nil.
+
+	if F.Value == nil {
+		return 0
+	}
+
+	// This code is needed on each of the fields for flexiblity.  If you need to gt a Field from the database and have in the
+	// code as a different Type.  Most of the time isn't going to be needed. This is (DEFAULT) conversion
+
+	switch v := F.Value.(type) {
+	case int:
+		// Interface is a Int, so just so the conversion. (DEFAULT)
+		return F.Value.(int)
+
+	case int32:
+		return int(F.Value.(int32))
+	case int64:
+		return int(F.Value.(int64))
+	case float64:
+		return int(F.Value.(float64))
+	case float32:
+		return int(F.Value.(float32))
+	case []uint8:
+		// Interface Value is an array of Characters Convert a string, then an Int
+		b, _ := F.Value.([]byte)
+		i, _ := strconv.Atoi(string(b))
+		return i
+	case string:
+		i, _ := strconv.Atoi(F.Value.(string))
+		return i
+
+	default:
+		l.Error("Can not convert type: '" + fmt.Sprintf("%T", v) + "' to an int")
+	}
+
+	return 0
 }
 
 func (F Field) AsInt64() int64 {
-    
-    // TODO:  If there is a NULL in the database.  the Interface is nil.
-    
-    if F.Value == nil {
-        return 0
-    }
-    
-    // This code is needed on each of the fields for flexiblity.  If you need to gt a Field from the database and have in the
-    // code as a different Type.  Most of the time isn't going to be needed. This is (DEFAULT) conversion
-    
-    switch v := F.Value.(type) {
-    case int:
-        // Interface is a Int, so just so the conversion. (DEFAULT)
-        return int64(F.Value.(int))
-    case int32:
-        return int64(F.Value.(int32))
-    case int64:
-        return F.Value.(int64)
-    case float64:
-        return int64(F.Value.(float64))
-    case float32:
-        return int64(F.Value.(float32))
-    case string:
-        i, _ := strconv.Atoi(F.Value.(string))
-        return int64(i)
-    
-    default:
-        l.Error("Can not convert type %T %v %v", v, v, F.Value)
-    }
-    
-    return 0
+
+	// TODO:  If there is a NULL in the database.  the Interface is nil.
+
+	if F.Value == nil {
+		return 0
+	}
+
+	// This code is needed on each of the fields for flexiblity.  If you need to gt a Field from the database and have in the
+	// code as a different Type.  Most of the time isn't going to be needed. This is (DEFAULT) conversion
+
+	switch v := F.Value.(type) {
+	case int:
+		// Interface is a Int, so just so the conversion. (DEFAULT)
+		return int64(F.Value.(int))
+	case int32:
+		return int64(F.Value.(int32))
+	case int64:
+		return F.Value.(int64)
+	case float64:
+		return int64(F.Value.(float64))
+	case float32:
+		return int64(F.Value.(float32))
+	case string:
+		i, _ := strconv.Atoi(F.Value.(string))
+		return int64(i)
+
+	default:
+		l.Error("Can not convert type %T %v %v", v, v, F.Value)
+	}
+
+	return 0
 }
 
 func (F Field) AsByte() []byte {
-    
-    if F.Value == nil {
-        return []byte{}
-    }
-    
-    switch v := F.Value.(type) {
-    
-    case []uint8:
-        // Interface Value is an array of Characters Convert a string, then an Int
-        b, _ := F.Value.([]byte)
-        return b
-    
-    case string:
-        return []byte(F.Value.(string))
-    
-    default:
-        l.Error("Can not convert type: '" + fmt.Sprintf("%T", v) + "' to a Bytes")
-    }
-    return []byte{}
+
+	if F.Value == nil {
+		return []byte{}
+	}
+
+	switch v := F.Value.(type) {
+
+	case []uint8:
+		// Interface Value is an array of Characters Convert a string, then an Int
+		b, _ := F.Value.([]byte)
+		return b
+
+	case string:
+		return []byte(F.Value.(string))
+
+	default:
+		l.Error("Can not convert type: '" + fmt.Sprintf("%T", v) + "' to a Bytes")
+	}
+	return []byte{}
 }

--- a/mysql/Insert.go
+++ b/mysql/Insert.go
@@ -1,61 +1,61 @@
 package mysql
 
 import (
-    "errors"
-    "fmt"
-    "reflect"
-    "strings"
-    "time"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
 )
 
 func (db *Database) Insert(dbStructure any) (string, error) {
-    
-    t := reflect.TypeOf(dbStructure)
-    InsertTable := ""
-    endsql := ""
-    buildsql := ""
-    for i := 0; i < t.NumField(); i++ {
-        field := t.Field(i)
-        tag := field.Tag.Get("db")
-        dbStructureMap := decodeTag(tag)
-        
-        if reflect.ValueOf(dbStructure).Field(i).CanInterface() {
-            value := reflect.ValueOf(dbStructure).Field(i).Interface()
-            // l.INFO("%d. Value='%v'  %v (%v), tag: '%v'\n", i+1, value, field.Name, field.Type.Name(), tag)
-            
-            if dbStructureMap["column"] == "" {
-                return "", errors.New("no column name specified for field" + field.Type.Name())
-            }
-            
-            if dbStructureMap["primarykey"] == "yes" {
-                // l.INFO("Primary Key Found: %s", dbStructureMap["table"])
-                InsertTable = dbStructureMap["table"]
-            }
-            
-            if dbStructureMap["omit"] != "yes" && dbStructureMap["primarykey"] != "yes" {
-                buildsql = buildsql + dbStructureMap["column"] + ","
-                
-                switch field.Type.Name() {
-                case "int", "int32", "int64":
-                    endsql = endsql + fmt.Sprintf("%v", value) + ","
-                case "string":
-                    endsql = endsql + hexRepresentation(value.(string)) + ","
-                case "float64":
-                    endsql = endsql + fmt.Sprintf("%v", value) + ","
-                case "Time":
-                    endsql = endsql + fmt.Sprintf("'%s'", value.(time.Time).Format("2006-01-02 15:04:05")) + ","
-                default:
-                    db.Logger.With("type", field.Type.Name()).With("value", value).Error("type error")
-                    endsql = endsql + "'" + value.(string) + "',"
-                }
-            }
-        }
-    }
-    // Get Rid of Trailling Comma
-    buildsql = strings.TrimSuffix(buildsql, ",")
-    endsql = strings.TrimSuffix(endsql, ",")
-    
-    SQL := "INSERT INTO " + InsertTable + "(" + buildsql + ") VALUES (" + endsql + ");"
-    
-    return SQL, nil
+
+	t := reflect.TypeOf(dbStructure)
+	InsertTable := ""
+	endsql := ""
+	buildsql := ""
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		tag := field.Tag.Get("db")
+		dbStructureMap := decodeTag(tag)
+
+		if reflect.ValueOf(dbStructure).Field(i).CanInterface() {
+			value := reflect.ValueOf(dbStructure).Field(i).Interface()
+			// l.INFO("%d. Value='%v'  %v (%v), tag: '%v'\n", i+1, value, field.Name, field.Type.Name(), tag)
+
+			if dbStructureMap["column"] == "" {
+				return "", errors.New("no column name specified for field" + field.Type.Name())
+			}
+
+			if dbStructureMap["primarykey"] == "yes" {
+				// l.INFO("Primary Key Found: %s", dbStructureMap["table"])
+				InsertTable = dbStructureMap["table"]
+			}
+
+			if dbStructureMap["omit"] != "yes" && dbStructureMap["primarykey"] != "yes" {
+				buildsql = buildsql + dbStructureMap["column"] + ","
+
+				switch field.Type.Name() {
+				case "uint8", "uint16", "uint32", "uint64", "int8", "int16", "int", "int32", "int64":
+					endsql = endsql + fmt.Sprintf("%v", value) + ","
+				case "string":
+					endsql = endsql + hexRepresentation(value.(string)) + ","
+				case "float32", "float64":
+					endsql = endsql + fmt.Sprintf("%v", value) + ","
+				case "Time":
+					endsql = endsql + fmt.Sprintf("'%s'", value.(time.Time).Format("2006-01-02 15:04:05")) + ","
+				default:
+					db.Logger.With("type", field.Type.Name()).With("value", value).Error("type error")
+					endsql = endsql + "'" + value.(string) + "',"
+				}
+			}
+		}
+	}
+	// Get Rid of Trailling Comma
+	buildsql = strings.TrimSuffix(buildsql, ",")
+	endsql = strings.TrimSuffix(endsql, ",")
+
+	SQL := "INSERT INTO " + InsertTable + "(" + buildsql + ") VALUES (" + endsql + ");"
+
+	return SQL, nil
 }

--- a/mysql/Insert_test.go
+++ b/mysql/Insert_test.go
@@ -5,20 +5,20 @@ import (
 	"time"
 )
 
-type Person[StatusType uint8 | uint16 | uint32 | uint64 | int | int8 | int16 | int32 | int64 | float32 | float64 | string] struct {
+type InsertPerson[StatusType uint8 | uint16 | uint32 | uint64 | int | int8 | int16 | int32 | int64 | float32 | float64 | string] struct {
 	Id      int        `db:"column=id primarykey=yes table=Users"`
 	Name    string     `db:"column=name"`
 	Dtadded time.Time  `db:"column=dtadded omit=yes"`
 	Status  StatusType `db:"column=status"`
 }
 
-func generatePerson[StatusType uint8 | uint16 | uint32 | uint64 | int | int8 | int16 | int32 | int64 | float32 | float64 | string](value StatusType) Person[StatusType] {
-	return Person[StatusType]{
+func generateInsertPerson[StatusType uint8 | uint16 | uint32 | uint64 | int | int8 | int16 | int32 | int64 | float32 | float64 | string](value StatusType) InsertPerson[StatusType] {
+	return InsertPerson[StatusType]{
 		0, "Test", time.Now(), value,
 	}
 }
 
-func testNumericalErrorValueHelper(t *testing.T, sql string, err error) {
+func testInsertNumericalErrorValueHelper(t *testing.T, sql string, err error) {
 	if err != nil {
 		t.Error(err)
 	}
@@ -28,7 +28,7 @@ func testNumericalErrorValueHelper(t *testing.T, sql string, err error) {
 	}
 }
 
-func testStringErrorValueHelper(t *testing.T, sql string, err error) {
+func testInsertStringErrorValueHelper(t *testing.T, sql string, err error) {
 	if err != nil {
 		t.Error(err)
 	}
@@ -41,29 +41,29 @@ func testStringErrorValueHelper(t *testing.T, sql string, err error) {
 func TestInsert(t *testing.T) {
 	New("", nil)
 
-	sql, err := DB.Insert(generatePerson(uint8(1)))
-	testNumericalErrorValueHelper(t, sql, err)
-	sql, err = DB.Insert(generatePerson(uint16(1)))
-	testNumericalErrorValueHelper(t, sql, err)
-	sql, err = DB.Insert(generatePerson(uint32(1)))
-	testNumericalErrorValueHelper(t, sql, err)
-	sql, err = DB.Insert(generatePerson(uint64(1)))
-	testNumericalErrorValueHelper(t, sql, err)
-	sql, err = DB.Insert(generatePerson(int(1)))
-	testNumericalErrorValueHelper(t, sql, err)
-	sql, err = DB.Insert(generatePerson(int8(1)))
-	testNumericalErrorValueHelper(t, sql, err)
-	sql, err = DB.Insert(generatePerson(int16(1)))
-	testNumericalErrorValueHelper(t, sql, err)
-	sql, err = DB.Insert(generatePerson(int32(1)))
-	testNumericalErrorValueHelper(t, sql, err)
-	sql, err = DB.Insert(generatePerson(int64(1)))
-	testNumericalErrorValueHelper(t, sql, err)
-	sql, err = DB.Insert(generatePerson(float32(1)))
-	testNumericalErrorValueHelper(t, sql, err)
-	sql, err = DB.Insert(generatePerson(float64(1)))
-	testNumericalErrorValueHelper(t, sql, err)
+	sql, err := DB.Insert(generateInsertPerson(uint8(1)))
+	testInsertNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Insert(generateInsertPerson(uint16(1)))
+	testInsertNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Insert(generateInsertPerson(uint32(1)))
+	testInsertNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Insert(generateInsertPerson(uint64(1)))
+	testInsertNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Insert(generateInsertPerson(int(1)))
+	testInsertNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Insert(generateInsertPerson(int8(1)))
+	testInsertNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Insert(generateInsertPerson(int16(1)))
+	testInsertNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Insert(generateInsertPerson(int32(1)))
+	testInsertNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Insert(generateInsertPerson(int64(1)))
+	testInsertNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Insert(generateInsertPerson(float32(1)))
+	testInsertNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Insert(generateInsertPerson(float64(1)))
+	testInsertNumericalErrorValueHelper(t, sql, err)
 
-	sql, err = DB.Insert(generatePerson("1"))
-	testStringErrorValueHelper(t, sql, err)
+	sql, err = DB.Insert(generateInsertPerson("1"))
+	testInsertStringErrorValueHelper(t, sql, err)
 }

--- a/mysql/Insert_test.go
+++ b/mysql/Insert_test.go
@@ -1,34 +1,69 @@
 package mysql
 
 import (
-    "testing"
-    "time"
+	"testing"
+	"time"
 )
 
-type Person struct {
-    Id      int       `db:"column=id primarykey=yes table=Users"`
-    Name    string    `db:"column=name"`
-    Dtadded time.Time `db:"column=dtadded omit=yes"`
-    Status  int       `db:"column=status"`
+type Person[StatusType uint8 | uint16 | uint32 | uint64 | int | int8 | int16 | int32 | int64 | float32 | float64 | string] struct {
+	Id      int        `db:"column=id primarykey=yes table=Users"`
+	Name    string     `db:"column=name"`
+	Dtadded time.Time  `db:"column=dtadded omit=yes"`
+	Status  StatusType `db:"column=status"`
+}
+
+func generatePerson[StatusType uint8 | uint16 | uint32 | uint64 | int | int8 | int16 | int32 | int64 | float32 | float64 | string](value StatusType) Person[StatusType] {
+	return Person[StatusType]{
+		0, "Test", time.Now(), value,
+	}
+}
+
+func testNumericalErrorValueHelper(t *testing.T, sql string, err error) {
+	if err != nil {
+		t.Error(err)
+	}
+
+	if sql != "INSERT INTO Users(name,status) VALUES (X'54657374',1);" {
+		t.Errorf("SQL Statement is not correct, found: %s", sql)
+	}
+}
+
+func testStringErrorValueHelper(t *testing.T, sql string, err error) {
+	if err != nil {
+		t.Error(err)
+	}
+
+	if sql != `INSERT INTO Users(name,status) VALUES (X'54657374',X'31');` {
+		t.Errorf("SQL Statement is not correct, found: %s", sql)
+	}
 }
 
 func TestInsert(t *testing.T) {
-    
-    p := Person{
-        Id:      0,
-        Name:    "Test",
-        Dtadded: time.Now(),
-        Status:  1,
-    }
-    
-    New("", nil)
-    
-    sql, err := DB.Insert(p)
-    if err != nil {
-        t.Error(err)
-    }
-    
-    if sql != "INSERT INTO Users(name,status) VALUES (X'54657374',1);" {
-        t.Error("SQL Statement is not correct")
-    }
+	New("", nil)
+
+	sql, err := DB.Insert(generatePerson(uint8(1)))
+	testNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Insert(generatePerson(uint16(1)))
+	testNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Insert(generatePerson(uint32(1)))
+	testNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Insert(generatePerson(uint64(1)))
+	testNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Insert(generatePerson(int(1)))
+	testNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Insert(generatePerson(int8(1)))
+	testNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Insert(generatePerson(int16(1)))
+	testNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Insert(generatePerson(int32(1)))
+	testNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Insert(generatePerson(int64(1)))
+	testNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Insert(generatePerson(float32(1)))
+	testNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Insert(generatePerson(float64(1)))
+	testNumericalErrorValueHelper(t, sql, err)
+
+	sql, err = DB.Insert(generatePerson("1"))
+	testStringErrorValueHelper(t, sql, err)
 }

--- a/mysql/Update.go
+++ b/mysql/Update.go
@@ -1,65 +1,65 @@
 package mysql
 
 import (
-    "errors"
-    "fmt"
-    "reflect"
-    "strings"
-    "time"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
 )
 
 func (db *Database) Update(dbStructure any) (string, error) {
-    
-    t := reflect.TypeOf(dbStructure)
-    UpdateTable := ""
-    buildsql := ""
-    UpdateColumn := ""
-    UpdateValue := ""
-    
-    for i := 0; i < t.NumField(); i++ {
-        field := t.Field(i)
-        tag := field.Tag.Get("db")
-        dbStructureMap := decodeTag(tag)
-        
-        if reflect.ValueOf(dbStructure).Field(i).CanInterface() {
-            value := reflect.ValueOf(dbStructure).Field(i).Interface()
-            // l.INFO("%d. Value='%v'  %v (%v), tag: '%v'\n", i+1, value, field.Name, field.Type.Name(), tag)
-            
-            // TODO: Need to look at way for this to happen and not though an error
-            if dbStructureMap["column"] == "" {
-                return "", errors.New("no column name specified for field '" + field.Type.Name() + "'")
-            }
-            
-            if dbStructureMap["primarykey"] == "yes" {
-                // l.INFO("Primary Key Found: %s", dbStructureMap["table"])
-                UpdateTable = dbStructureMap["table"]
-                UpdateColumn = dbStructureMap["column"]
-                UpdateValue = fmt.Sprintf("%v", value)
-            }
-            
-            if dbStructureMap["omit"] != "yes" && dbStructureMap["primarykey"] != "yes" {
-                buildsql = buildsql + dbStructureMap["column"] + "="
-                
-                switch field.Type.Name() {
-                case "int", "int32", "int64":
-                    buildsql = buildsql + fmt.Sprintf("%v", value) + ","
-                case "string":
-                    buildsql = buildsql + hexRepresentation(value.(string)) + ","
-                case "float64":
-                    buildsql = buildsql + fmt.Sprintf("%v", value) + ","
-                case "Time":
-                    buildsql = buildsql + fmt.Sprintf("'%s'", value.(time.Time).Format("2006-01-02 15:04:05")) + ","
-                default:
-                    db.Logger.With("type", field.Type.Name()).With("value", value).Error("type error")
-                    buildsql = buildsql + "'" + value.(string) + "',"
-                }
-            }
-        }
-    }
-    // Get Rid of Trailing Comma
-    
-    buildsql = strings.TrimSuffix(buildsql, ",")
-    SQL := "UPDATE " + UpdateTable + " SET " + buildsql + " WHERE " + UpdateColumn + "=" + UpdateValue + ";"
-    
-    return SQL, nil
+
+	t := reflect.TypeOf(dbStructure)
+	UpdateTable := ""
+	buildsql := ""
+	UpdateColumn := ""
+	UpdateValue := ""
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		tag := field.Tag.Get("db")
+		dbStructureMap := decodeTag(tag)
+
+		if reflect.ValueOf(dbStructure).Field(i).CanInterface() {
+			value := reflect.ValueOf(dbStructure).Field(i).Interface()
+			// l.INFO("%d. Value='%v'  %v (%v), tag: '%v'\n", i+1, value, field.Name, field.Type.Name(), tag)
+
+			// TODO: Need to look at way for this to happen and not though an error
+			if dbStructureMap["column"] == "" {
+				return "", errors.New("no column name specified for field '" + field.Type.Name() + "'")
+			}
+
+			if dbStructureMap["primarykey"] == "yes" {
+				// l.INFO("Primary Key Found: %s", dbStructureMap["table"])
+				UpdateTable = dbStructureMap["table"]
+				UpdateColumn = dbStructureMap["column"]
+				UpdateValue = fmt.Sprintf("%v", value)
+			}
+
+			if dbStructureMap["omit"] != "yes" && dbStructureMap["primarykey"] != "yes" {
+				buildsql = buildsql + dbStructureMap["column"] + "="
+
+				switch field.Type.Name() {
+				case "uint8", "uint16", "uint32", "uint64", "int8", "int16", "int", "int32", "int64":
+					buildsql = buildsql + fmt.Sprintf("%v", value) + ","
+				case "string":
+					buildsql = buildsql + hexRepresentation(value.(string)) + ","
+				case "float32", "float64":
+					buildsql = buildsql + fmt.Sprintf("%v", value) + ","
+				case "Time":
+					buildsql = buildsql + fmt.Sprintf("'%s'", value.(time.Time).Format("2006-01-02 15:04:05")) + ","
+				default:
+					db.Logger.With("type", field.Type.Name()).With("value", value).Error("type error")
+					buildsql = buildsql + "'" + value.(string) + "',"
+				}
+			}
+		}
+	}
+	// Get Rid of Trailing Comma
+
+	buildsql = strings.TrimSuffix(buildsql, ",")
+	SQL := "UPDATE " + UpdateTable + " SET " + buildsql + " WHERE " + UpdateColumn + "=" + UpdateValue + ";"
+
+	return SQL, nil
 }

--- a/mysql/Update_test.go
+++ b/mysql/Update_test.go
@@ -1,37 +1,69 @@
 package mysql
 
 import (
-    "testing"
-    "time"
+	"testing"
+	"time"
 )
 
-type UpdatePerson struct {
-    Id      int       `db:"column=id primarykey=yes table=Users"`
-    Name    string    `db:"column=name"`
-    Dtadded time.Time `db:"column=dtadded omit=yes"`
-    Status  int       `db:"column=status"`
+type UpdatePerson[StatusType uint8 | uint16 | uint32 | uint64 | int | int8 | int16 | int32 | int64 | float32 | float64 | string] struct {
+	Id      int        `db:"column=id primarykey=yes table=Users"`
+	Name    string     `db:"column=name"`
+	Dtadded time.Time  `db:"column=dtadded omit=yes"`
+	Status  StatusType `db:"column=status"`
+}
+
+func generateUpdatePerson[StatusType uint8 | uint16 | uint32 | uint64 | int | int8 | int16 | int32 | int64 | float32 | float64 | string](value StatusType) UpdatePerson[StatusType] {
+	return UpdatePerson[StatusType]{
+		0, "Test", time.Now(), value,
+	}
+}
+
+func testUpdateNumericalErrorValueHelper(t *testing.T, sql string, err error) {
+	if err != nil {
+		t.Error(err)
+	}
+
+	if sql != "UPDATE Users SET name=X'54657374',status=1 WHERE id=12;" {
+		t.Errorf("SQL Statement is not correct, found: %s", sql)
+	}
+}
+
+func testUpdateStringErrorValueHelper(t *testing.T, sql string, err error) {
+	if err != nil {
+		t.Error(err)
+	}
+
+	if sql != `UPDATE Users SET name=X'54657374',status=X='31 WHERE id=12;` {
+		t.Errorf("SQL Statement is not correct, found: %s", sql)
+	}
 }
 
 func TestUpdate(t *testing.T) {
-    
-    p := UpdatePerson{
-        Id:      12,
-        Name:    "Test",
-        Dtadded: time.Now(),
-        Status:  1,
-    }
-    
-    New("", nil)
-    
-    sql, err := DB.Update(p)
-    if err != nil {
-        t.Error(err)
-    }
-    
-    // UPDATE Users SET name = X'54657374',status=1 WHERE id=12;
-    // UPDATE Users SET name=X'54657374',status=1 WHERE id=12;
-    
-    if sql != "UPDATE Users SET name=X'54657374',status=1 WHERE id=12;" {
-        t.Errorf("SQL Statement is not correct SQL: %s", sql)
-    }
+	New("", nil)
+
+	sql, err := DB.Update(generateUpdatePerson(uint8(1)))
+	testUpdateNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Update(generateUpdatePerson(uint16(1)))
+	testUpdateNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Update(generateUpdatePerson(uint32(1)))
+	testUpdateNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Update(generateUpdatePerson(uint64(1)))
+	testUpdateNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Update(generateUpdatePerson(int(1)))
+	testUpdateNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Update(generateUpdatePerson(int8(1)))
+	testUpdateNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Update(generateUpdatePerson(int16(1)))
+	testUpdateNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Update(generateUpdatePerson(int32(1)))
+	testUpdateNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Update(generateUpdatePerson(int64(1)))
+	testUpdateNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Update(generateUpdatePerson(float32(1)))
+	testUpdateNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Update(generateUpdatePerson(float64(1)))
+	testUpdateNumericalErrorValueHelper(t, sql, err)
+
+	sql, err = DB.Update(generateUpdatePerson("1"))
+	testUpdateStringErrorValueHelper(t, sql, err)
 }


### PR DESCRIPTION
- Added support for uint8, uint16, uint32, uint64, int8, int16 in Insert()
- Added support and fixed panic for float32 in QueryStruct where if MySQL had the data type "float", MySQL would return float32 type but AsFloat() did not support float32 and attempted to access float64 interface, which threw a panic.
- Added support for int types in AsFloat64 as well.
- Fixed panic in Update that comes from not supporting float32, which would cause it enter the default clause, where the function would attempt to infer "string" from it, which would lead to a panic.