### PR TITLE
Added DB.Save() along with some fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,9 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
+	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/mattn/go-sqlite3 v1.14.24 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,14 @@
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
+github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=
+github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/mysql/Fields.go
+++ b/mysql/Fields.go
@@ -177,9 +177,28 @@ func (F Field) AsInt64() int64 {
 	// code as a different Type.  Most of the time isn't going to be needed. This is (DEFAULT) conversion
 
 	switch v := F.Value.(type) {
+	case bool:
+		if F.Value.(bool) {
+			return int64(1)
+		}
+		return int64(0)
+	case uint:
+		return int64(F.Value.(uint))
+	case uint8:
+		return int64(F.Value.(uint8))
+	case uint16:
+		return int64(F.Value.(uint16))
+	case uint32:
+		return int64(F.Value.(uint32))
+	case uint64:
+		return int64(F.Value.(uint64))
 	case int:
 		// Interface is a Int, so just so the conversion. (DEFAULT)
 		return int64(F.Value.(int))
+	case int8:
+		return int64(F.Value.(int8))
+	case int16:
+		return int64(F.Value.(int16))
 	case int32:
 		return int64(F.Value.(int32))
 	case int64:
@@ -197,6 +216,97 @@ func (F Field) AsInt64() int64 {
 	}
 
 	return 0
+}
+
+func (F Field) AsUInt64() uint64 {
+	if F.Value == nil {
+		return 0
+	}
+
+	// This code is needed on each of the fields for flexiblity.  If you need to gt a Field from the database and have in the
+	// code as a different Type.  Most of the time isn't going to be needed. This is (DEFAULT) conversion
+
+	switch v := F.Value.(type) {
+	case bool:
+		if F.Value.(bool) {
+			return uint64(1)
+		}
+		return uint64(0)
+	case uint:
+		return uint64(F.Value.(uint))
+	case uint8:
+		return uint64(F.Value.(uint8))
+	case uint16:
+		return uint64(F.Value.(uint16))
+	case uint32:
+		return uint64(F.Value.(uint32))
+	case uint64:
+		return F.Value.(uint64)
+	case int:
+		// Interface is a Int, so just so the conversion. (DEFAULT)
+		return uint64(F.Value.(int))
+	case int8:
+		return uint64(F.Value.(int8))
+	case int16:
+		return uint64(F.Value.(int16))
+	case int32:
+		return uint64(F.Value.(int32))
+	case int64:
+		return uint64(F.Value.(int64))
+	case float64:
+		return uint64(F.Value.(float64))
+	case float32:
+		return uint64(F.Value.(float32))
+	case string:
+		i, _ := strconv.Atoi(F.Value.(string))
+		return uint64(i)
+
+	default:
+		l.Error("Can not convert type %T %v %v", v, v, F.Value)
+	}
+
+	return 0
+}
+
+func (F Field) AsBool() bool {
+	if F.Value == nil {
+		return false
+	}
+
+	switch v := F.Value.(type) {
+	case bool:
+		return F.Value.(bool)
+	case uint:
+		return convToBool(F.Value.(uint))
+	case uint8:
+		return convToBool(F.Value.(uint8))
+	case uint16:
+		return convToBool(F.Value.(uint16))
+	case uint32:
+		return convToBool(F.Value.(uint32))
+	case uint64:
+		return convToBool(F.Value.(uint64))
+	case int:
+		// Interface is a Int, so just so the conversion. (DEFAULT)
+		return convToBool(F.Value.(int))
+	case int8:
+		return convToBool(F.Value.(int8))
+	case int16:
+		return convToBool(F.Value.(int16))
+	case int32:
+		return convToBool(F.Value.(int32))
+	case int64:
+		return convToBool(F.Value.(int64))
+	case float64:
+		return convToBool(F.Value.(float64))
+	case float32:
+		return convToBool(F.Value.(float32))
+	case string:
+		return len(F.Value.(string)) > 0
+	default:
+		l.Error("Can not convert type: '" + fmt.Sprintf("%T", v) + "' to a bool")
+	}
+	return false
 }
 
 func (F Field) AsByte() []byte {
@@ -219,4 +329,17 @@ func (F Field) AsByte() []byte {
 		l.Error("Can not convert type: '" + fmt.Sprintf("%T", v) + "' to a Bytes")
 	}
 	return []byte{}
+}
+
+func convToBool[T uint | uint8 | uint16 | uint32 | uint64 | int | int8 | int16 | int32 | int64 | float32 | float64](value T) bool {
+	switch any(value).(type) {
+	case uint, uint8, uint16, uint32, uint64:
+		return value != 0
+	case int, int8, int16, int32, int64:
+		return value != 0
+	case float32, float64:
+		return value != 0.0
+	default:
+		return false
+	}
 }

--- a/mysql/Insert.go
+++ b/mysql/Insert.go
@@ -111,6 +111,8 @@ func generateValuesSql(dbStructure any, t reflect.Type) (string, error) {
 					sb.WriteString(hexRepresentation(value.(string)) + ",")
 				case "float32", "float64":
 					sb.WriteString(fmt.Sprintf("%v,", value))
+				case "bool":
+					sb.WriteString(fmt.Sprintf("%v,", value))
 				case "Time":
 					sb.WriteString(fmt.Sprintf("'%s',", value.(time.Time).Format("2006-01-02 15:04:05")))
 				default:

--- a/mysql/Insert.go
+++ b/mysql/Insert.go
@@ -75,7 +75,7 @@ func generateBuildSql(dbStructure any, t reflect.Type) (table string, buildSql s
 				return "", "", errors.New("no column name specified for field " + field.Name)
 			}
 
-			if dbStructureMap["primarykey"] == "yes" {
+			if dbStructureMap["table"] != "" {
 				table = dbStructureMap["table"]
 			}
 

--- a/mysql/Query.go
+++ b/mysql/Query.go
@@ -1,66 +1,75 @@
 package mysql
 
+import "fmt"
+
 func (db *Database) Query(sql string, parameters ...any) ([]Record, error) {
-    
-    allRecords := make([]Record, 0)
-    
-    DatabaseConnection, err := getConnection()
-    if err != nil {
-        return allRecords, err
-    }
-    
-    rows, err := DatabaseConnection.Query(sql, parameters...)
-    
-    if err != nil {
-        return allRecords, err
-    }
-    defer rows.Close()
-    
-    columns, _ := rows.Columns()
-    count := len(columns)
-    values := make([]interface{}, count)
-    valuePtrs := make([]interface{}, count)
-    
-    for rows.Next() {
-        for i := range columns {
-            valuePtrs[i] = &values[i]
-        }
-        _ = rows.Scan(valuePtrs...)
-        
-        out := Record{}
-        
-        for i, col := range columns {
-            val := values[i]
-            
-            // TODO: Implement All the Types!
-            
-            // nolint:gosimple
-            switch val.(type) {
-            case int64:
-                // fmt.Printf("Int: %v\n", val)
-                out[col] = Field{Value: val}
-            case float64:
-                // fmt.Printf("Float64: %v\n", val)
-                out[col] = Field{Value: val}
-            
-            case []uint8:
-                b, _ := val.([]byte)
-                // fmt.Printf("String: %s\n", string(b))
-                // l.INFO("Type: %T", val)
-                out[col] = Field{Value: string(b)}
-            
-            case interface{}:
-                // l.ERROR("Unknown Type: %T", val)
-                // If the Record is NULL
-                out[col] = Field{Value: val}
-            
-            default:
-                // l.ERROR("Unknown Type: %T", val)
-                out[col] = Field{Value: val}
-            }
-        }
-        allRecords = append(allRecords, out)
-    }
-    
-    return allRecords, nil
+
+	allRecords := make([]Record, 0)
+
+	DatabaseConnection, err := getConnection()
+	if err != nil {
+		return allRecords, err
+	}
+	fmt.Printf("sql: %s params: %+v\n", sql, parameters)
+	rows, err := DatabaseConnection.Query(sql, parameters...)
+
+	if err != nil {
+		return allRecords, err
+	}
+	defer rows.Close()
+
+	columns, _ := rows.Columns()
+	count := len(columns)
+	values := make([]interface{}, count)
+	valuePtrs := make([]interface{}, count)
+
+	for rows.Next() {
+		fmt.Println("PONG")
+		for i := range columns {
+			valuePtrs[i] = &values[i]
+		}
+		if err := rows.Scan(valuePtrs...); err != nil {
+			fmt.Printf("ERROR: %s\n", err.Error())
+		}
+
+		out := Record{}
+
+		for i, col := range columns {
+			val := values[i]
+
+			// TODO: Implement All the Types!
+
+			// nolint:gosimple
+			switch val.(type) {
+			case uint, uint8, uint16, uint32, uint64, int, int8, int16, int32, int64:
+				// fmt.Printf("Int: %v\n", val)
+				out[col] = Field{Value: val}
+			case float32, float64:
+				// fmt.Printf("Float64: %v\n", val)
+				out[col] = Field{Value: val}
+			case bool:
+				out[col] = Field{Value: val}
+			case string:
+				out[col] = Field{Value: val}
+
+			case []uint8:
+				b, _ := val.([]byte)
+				// fmt.Printf("String: %s\n", string(b))
+				// l.INFO("Type: %T", val)
+				out[col] = Field{Value: string(b)}
+
+			case interface{}:
+				// l.ERROR("Unknown Type: %T", val)
+				// If the Record is NULL
+				out[col] = Field{Value: val}
+
+			default:
+				// l.ERROR("Unknown Type: %T", val)
+				out[col] = Field{Value: val}
+			}
+		}
+		allRecords = append(allRecords, out)
+	}
+
+	return allRecords, nil
 }

--- a/mysql/QueryStruct.go
+++ b/mysql/QueryStruct.go
@@ -1,7 +1,6 @@
 package mysql
 
 import (
-	"fmt"
 	"reflect"
 
 	l "log/slog"
@@ -16,8 +15,6 @@ func QueryStruct[T any](sql string, parameters ...any) ([]T, error) {
 	if err != nil {
 		return make([]T, 0), err
 	}
-
-	fmt.Printf("Records: %+v\n", allRecords)
 
 	results := make([]T, 0)
 

--- a/mysql/QueryStruct.go
+++ b/mysql/QueryStruct.go
@@ -1,77 +1,86 @@
 package mysql
 
 import (
-    "reflect"
-    
-    l "log/slog"
+	"fmt"
+	"reflect"
+
+	l "log/slog"
 )
 
 // You can't do Method Generic types in Go, so we have to use a function.
 
 func QueryStruct[T any](sql string, parameters ...any) ([]T, error) {
-    
-    // First of all, get all the database records, ising the old Record/Field method.
-    allRecords, err := DB.Query(sql, parameters...)
-    if err != nil {
-        return make([]T, 0), err
-    }
-    
-    results := make([]T, 0)
-    
-    for i, record := range allRecords {
-        var newStructRecord T
-        
-        for k, v := range record {
-            // Use Reflection to set the value.
-            
-            structFieldName, structFieldType := getStructDetails[T](k)
-            
-            // l.INFO("index:%d Key:%s Value:%v structFieldName:%v structFieldType:%v", i, k, "", structFieldName, structFieldType)
-            
-            switch structFieldType {
-            case "int", "int32", "int64":
-                // l.INFO("Setting Int64 field: %s to %v type: %T", structFieldName, v.Value, v.Value)
-                reflect.ValueOf(&newStructRecord).Elem().FieldByName(structFieldName).SetInt(v.AsInt64())
-            
-            case "float32", "float64":
-                // l.INFO("Setting flaot64 field: %s to %v", structFieldName, v.Value)
-                reflect.ValueOf(&newStructRecord).Elem().FieldByName(structFieldName).SetFloat(v.AsFloat())
-            
-            case "string":
-                // l.INFO("Setting String field: %s to %v", structFieldName, v.Value)
-                reflect.ValueOf(&newStructRecord).Elem().FieldByName(structFieldName).SetString(v.AsString())
-            
-            case "Time":
-                // l.INFO("Setting Time field: %s to %v", structFieldName, v.Value)
-                reflect.ValueOf(&newStructRecord).Elem().FieldByName(structFieldName).Set(reflect.ValueOf(v.AsDate("")))
-                
-                // Add Blob Support.
-            case "[]uint8":
-                reflect.ValueOf(&newStructRecord).Elem().FieldByName(structFieldName).Set(reflect.ValueOf(v.AsByte()))
-                // l.INFO("Setting Blob field: %s to %v", structFieldName, v.Value)
-            
-            default:
-                l.With("col", k).With("index", i).With("structFieldName", structFieldName).With("structFieldType", structFieldType).Error("Database column was not found")
-            }
-        }
-        
-        results = append(results, newStructRecord)
-    }
-    return results, nil
+
+	// First of all, get all the database records, ising the old Record/Field method.
+	allRecords, err := DB.Query(sql, parameters...)
+	if err != nil {
+		return make([]T, 0), err
+	}
+
+	fmt.Printf("Records: %+v\n", allRecords)
+
+	results := make([]T, 0)
+
+	for i, record := range allRecords {
+		var newStructRecord T
+
+		for k, v := range record {
+			// Use Reflection to set the value.
+
+			structFieldName, structFieldType := getStructDetails[T](k)
+
+			// l.INFO("index:%d Key:%s Value:%v structFieldName:%v structFieldType:%v", i, k, "", structFieldName, structFieldType)
+
+			switch structFieldType {
+			case "int", "int8", "int16", "int32", "int64":
+				// l.INFO("Setting Int64 field: %s to %v type: %T", structFieldName, v.Value, v.Value)
+				reflect.ValueOf(&newStructRecord).Elem().FieldByName(structFieldName).SetInt(v.AsInt64())
+
+			case "uint", "uint8", "uint16", "uint32", "uint64":
+				reflect.ValueOf(&newStructRecord).Elem().FieldByName(structFieldName).SetUint(v.AsUInt64())
+
+			case "bool":
+				reflect.ValueOf(&newStructRecord).Elem().FieldByName(structFieldName).SetBool(v.AsBool())
+
+			case "float32", "float64":
+				// l.INFO("Setting flaot64 field: %s to %v", structFieldName, v.Value)
+				reflect.ValueOf(&newStructRecord).Elem().FieldByName(structFieldName).SetFloat(v.AsFloat())
+
+			case "string":
+				// l.INFO("Setting String field: %s to %v", structFieldName, v.Value)
+				reflect.ValueOf(&newStructRecord).Elem().FieldByName(structFieldName).SetString(v.AsString())
+
+			case "Time":
+				// l.INFO("Setting Time field: %s to %v", structFieldName, v.Value)
+				reflect.ValueOf(&newStructRecord).Elem().FieldByName(structFieldName).Set(reflect.ValueOf(v.AsDate("")))
+
+				// Add Blob Support.
+			case "[]uint8":
+				reflect.ValueOf(&newStructRecord).Elem().FieldByName(structFieldName).Set(reflect.ValueOf(v.AsByte()))
+				// l.INFO("Setting Blob field: %s to %v", structFieldName, v.Value)
+
+			default:
+				l.With("col", k).With("index", i).With("structFieldName", structFieldName).With("structFieldType", structFieldType).Error("Database column was not found")
+			}
+		}
+
+		results = append(results, newStructRecord)
+	}
+	return results, nil
 }
 
 // You can't do Method Generic types in Go, so we have to use a function.
 
 func QuerySingleStruct[T any](sql string, parameters ...any) (T, error) {
-    
-    var SingleResult T
-    
-    results, err := QueryStruct[T](sql, parameters...)
-    if err != nil {
-        return SingleResult, err
-    }
-    if len(results) == 0 {
-        return SingleResult, nil
-    }
-    return results[0], nil
+
+	var SingleResult T
+
+	results, err := QueryStruct[T](sql, parameters...)
+	if err != nil {
+		return SingleResult, err
+	}
+	if len(results) == 0 {
+		return SingleResult, nil
+	}
+	return results[0], nil
 }

--- a/mysql/Save.go
+++ b/mysql/Save.go
@@ -1,0 +1,30 @@
+package mysql
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+// Save takes in a structure and if the primary key value is set to a non-zero value, then it will update the object
+// else it will insert the object into the table (taking in a primary key to reduce reflection overhead)
+func (db *Database) Save(dbStructure any, primaryKeyValue any) (lastInsertedID, rowsAffected int64, err error) {
+	pkvValue := reflect.ValueOf(primaryKeyValue) //pkv => Primary Key Value
+	if !pkvValue.IsValid() {
+		return 0, 0, errors.New("invalid primary key value")
+	}
+	var sql string
+	if pkvValue.IsZero() {
+		sql, err = DB.Insert(dbStructure)
+		if err != nil {
+			return 0, 0, err
+		}
+		fmt.Printf("insert sql: %s\n", sql)
+	} else {
+		sql, err = DB.Update(dbStructure)
+		if err != nil {
+			return 0, 0, err
+		}
+	}
+	return DB.Execute(sql)
+}

--- a/mysql/Save.go
+++ b/mysql/Save.go
@@ -2,7 +2,6 @@ package mysql
 
 import (
 	"errors"
-	"fmt"
 	"reflect"
 )
 
@@ -19,7 +18,6 @@ func (db *Database) Save(dbStructure any, primaryKeyValue any) (lastInsertedID, 
 		if err != nil {
 			return 0, 0, err
 		}
-		fmt.Printf("insert sql: %s\n", sql)
 	} else {
 		sql, err = DB.Update(dbStructure)
 		if err != nil {

--- a/mysql/Save_integration_test.go
+++ b/mysql/Save_integration_test.go
@@ -1,0 +1,232 @@
+package mysql
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"database/sql"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+)
+
+type IntegrationTestingSaveTestCase[T comparable] struct {
+	name          string
+	pkeyValue     T
+	sqlColumnType string
+}
+
+// setUpIntegrationTest sets up the SQL Lite connection
+func setUpSaveIntegrationTestConnection(t *testing.T) string {
+	tempFile, err := os.CreateTemp("", "integration-test-*.db")
+	assert.NoError(t, err)
+	db, err := sql.Open("sqlite3", tempFile.Name())
+	assert.NoError(t, err)
+
+	New("test/test", slog.Default())
+	DB.dbConnection = db
+	DB.connected = true
+	return tempFile.Name()
+}
+
+// setUpIntegrationSaveTable sets up the table for the testing
+func setUpIntegrationSaveTable(t *testing.T, SQLColumnType string) {
+	tearDownIntegrationSaveTable(t)
+	_, err := DB.dbConnection.Exec(fmt.Sprintf(`
+        CREATE TABLE Users (
+            id %s PRIMARY KEY,
+            name TEXT,
+            status INT,
+            dtadded DATETIME
+        )
+    `, SQLColumnType))
+	assert.NoError(t, err)
+}
+
+// tearDownIntegrationSaveTable deletes the table after use
+func tearDownIntegrationSaveTable(t *testing.T) {
+	_, err := DB.dbConnection.Exec(`DROP TABLE IF EXISTS Users;`)
+	assert.NoError(t, err)
+}
+
+// tearDownSaveIntegrationTestConnection closes the sql lite connection
+func tearDownIntegrationSaveTestConnection(t *testing.T, filename string) {
+	err := DB.dbConnection.Close()
+	assert.NoError(t, err)
+	os.Remove(filename)
+}
+
+// testIntegrationSaveTestHelper is the core tester for all kinds of types, not considering "bool" because who uses bool as a pkey value
+func testIntegrationSaveTestHelper[T comparable](t *testing.T, testCases []IntegrationTestingSaveTestCase[T]) {
+	// setup sql lite connection
+	filename := setUpSaveIntegrationTestConnection(t)
+	defer tearDownIntegrationSaveTestConnection(t, filename)
+
+	// this is how it will appear in the table
+	type IntegrationGenericStruct[V comparable] struct {
+		Id     V      `db:"column=id primarykey=yes table=Users"`
+		Name   string `db:"column=name"`
+		Status int    `db:"column=status"`
+	}
+
+	// made this struct separate because insert ignores pkey column in the insert query and we want to set that specifically
+	// in the insert query
+	type IntegrationInsertGenericStruct[V comparable] struct {
+		Id     V      `db:"column=id table=Users"`
+		Name   string `db:"column=name"`
+		Status int    `db:"column=status"`
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// create the Users table, and drop it after done
+			setUpIntegrationSaveTable(t, tc.sqlColumnType)
+			defer tearDownIntegrationSaveTable(t)
+
+			value := reflect.ValueOf(tc.pkeyValue)
+			// this is to separate out into insert and update modes of the DB.Save() function
+			if value.IsValid() && value.IsZero() {
+				entry := IntegrationInsertGenericStruct[T]{
+					Id:     tc.pkeyValue,
+					Name:   "Test",
+					Status: 1,
+				}
+				// insert into table, not checking lastInsertedId because right now it only returns int64, will fail for other types
+				// like strings and floats
+				_, rowsAffected, err := DB.Save(entry, entry.Id)
+				assert.NoError(t, err)
+				assert.Equal(t, int64(1), rowsAffected)
+				// check if value was successfully created in table
+				result, err := QuerySingleStruct[IntegrationGenericStruct[T]]("SELECT id,name,status from Users WHERE id=?", tc.pkeyValue)
+				assert.NoError(t, err)
+				assert.Equal(t, tc.pkeyValue, result.Id)
+				assert.Equal(t, "Test", result.Name)
+				assert.Equal(t, int(1), result.Status)
+				return
+			}
+			// update table mode of DB.Save(), we first insert into table
+			var rowsAffected int64
+			var err error
+			// separating out because of error of unsupported values with high bit set in case of uint64
+			if value.Type().Name() == "uint64" {
+				_, rowsAffected, err = DB.Execute("INSERT INTO Users(id,name,status) VALUES (?,?,?)", strconv.FormatUint(value.Uint(), 10), "Test", 1)
+			} else {
+				_, rowsAffected, err = DB.Execute("INSERT INTO Users(id,name,status) VALUES (?,?,?)", tc.pkeyValue, "Test", 1)
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, int64(1), rowsAffected)
+			// now update value
+			updatedEntry := IntegrationGenericStruct[T]{
+				Id:     tc.pkeyValue,
+				Name:   "Test1",
+				Status: 1,
+			}
+			_, rowsAffected, err = DB.Save(updatedEntry, updatedEntry.Id)
+			assert.NoError(t, err)
+			assert.Equal(t, int64(1), rowsAffected)
+			// same bit set error handling, and now we check if value successfully changed in table
+			var result IntegrationGenericStruct[T]
+			if value.Type().Name() == "uint64" {
+				result, err = QuerySingleStruct[IntegrationGenericStruct[T]]("SELECT id,name,status from Users WHERE id=?", strconv.FormatUint(value.Uint(), 10))
+			} else {
+				result, err = QuerySingleStruct[IntegrationGenericStruct[T]]("SELECT id,name,status from Users WHERE id=?", tc.pkeyValue)
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.pkeyValue, result.Id)
+			assert.Equal(t, "Test1", result.Name)
+			assert.Equal(t, int(1), result.Status)
+		})
+	}
+}
+
+// TestSaveIntegrationUintType tests all uint types
+func TestSaveIntegrationUintType(t *testing.T) {
+	testUintCases := []IntegrationTestingSaveTestCase[uint]{
+		{"Uint Zero", uint(0), `INT UNSIGNED`},
+		{"Uint Non-Zero", uint(42), `INT UNSIGNED`},
+	}
+	testIntegrationSaveTestHelper[uint](t, testUintCases)
+	testUint8Cases := []IntegrationTestingSaveTestCase[uint8]{
+		{"Uint8 Zero", uint8(0), `TINYINT UNSIGNED`},
+		{"Uint8 Non-Zero", uint8(255), `TINYINT UNSIGNED`},
+	}
+	testIntegrationSaveTestHelper[uint8](t, testUint8Cases)
+	testUint16Cases := []IntegrationTestingSaveTestCase[uint16]{
+		{"Uint16 Zero", uint16(0), `SMALLINT UNSIGNED`},
+		{"Uint16 Non-Zero", uint16(65535), `SMALLINT UNSIGNED`},
+	}
+	testIntegrationSaveTestHelper[uint16](t, testUint16Cases)
+	testUint32Cases := []IntegrationTestingSaveTestCase[uint32]{
+		{"Uint32 Zero", uint32(0), `INT UNSIGNED`},
+		{"Uint32 Non-Zero", uint32(4294967295), `INT UNSIGNED`},
+	}
+	testIntegrationSaveTestHelper[uint32](t, testUint32Cases)
+	testUint64Cases := []IntegrationTestingSaveTestCase[uint64]{
+		{"Uint64 Zero", uint64(0), `BIGINT UNSIGNED`},
+		{"Uint64 Non-Zero", uint64(18446744073709551615), `BIGINT UNSIGNED`},
+	}
+	testIntegrationSaveTestHelper[uint64](t, testUint64Cases)
+}
+
+// TestSaveIntegrationIntType tests all int types
+func TestSaveIntegrationIntType(t *testing.T) {
+	testIntCases := []IntegrationTestingSaveTestCase[int]{
+		{"Int Zero", 0, `INT`},
+		{"Int Positive", 42, `INT`},
+		{"Int Negative", -42, `INT`},
+	}
+	testIntegrationSaveTestHelper[int](t, testIntCases)
+	testInt8Cases := []IntegrationTestingSaveTestCase[int8]{
+		{"Int8 Zero", int8(0), `TINYINT`},
+		{"Int8 Positive", int8(127), `TINYINT`},
+		{"Int8 Negative", int8(-128), `TINYINT`},
+	}
+	testIntegrationSaveTestHelper[int8](t, testInt8Cases)
+	testInt16Cases := []IntegrationTestingSaveTestCase[int16]{
+		{"Int16 Zero", int16(0), `SMALLINT`},
+		{"Int16 Positive", int16(32767), `SMALLINT`},
+		{"Int16 Negative", int16(-32768), `SMALLINT`},
+	}
+	testIntegrationSaveTestHelper[int16](t, testInt16Cases)
+	testInt32Cases := []IntegrationTestingSaveTestCase[int32]{
+		{"Int32 Zero", int32(0), `INT`},
+		{"Int32 Positive", int32(2147483647), `INT`},
+		{"Int32 Negative", int32(-2147483648), `INT`},
+	}
+	testIntegrationSaveTestHelper[int32](t, testInt32Cases)
+	testInt64Cases := []IntegrationTestingSaveTestCase[int64]{
+		{"Int64 Zero", int64(0), `BIGINT`},
+		{"Int64 Positive", int64(9223372036854775807), `BIGINT`},
+		{"Int64 Negative", int64(-9223372036854775808), `BIGINT`},
+	}
+	testIntegrationSaveTestHelper[int64](t, testInt64Cases)
+}
+
+// TestSaveIntegrationTestFloatType tests all float types
+func TestSaveIntegrationTestFloatType(t *testing.T) {
+	testFloat32Cases := []IntegrationTestingSaveTestCase[float32]{
+		{"Float32 Zero", float32(0), `FLOAT`},
+		// not checking non-zero values because of precision issues failing to find the exact value of id
+	}
+	testIntegrationSaveTestHelper[float32](t, testFloat32Cases)
+	testFloat64Cases := []IntegrationTestingSaveTestCase[float64]{
+		{"Float64 Zero", float64(0), `DOUBLE`},
+		{"Float64 Positive", float64(3.14159), `DOUBLE`},
+		{"Float64 Negative", float64(-3.14159), `DOUBLE`},
+	}
+	testIntegrationSaveTestHelper[float64](t, testFloat64Cases)
+}
+
+// TestSaveIntegrationTestStringType tests all string types
+func TestSaveIntegrationTestStringType(t *testing.T) {
+	testStringCases := []IntegrationTestingSaveTestCase[string]{
+		// not handling empty string, because its not considered as an actual entry in a primary key value
+		{"String Non-Empty", "42", `VARCHAR(255)`},
+	}
+	testIntegrationSaveTestHelper[string](t, testStringCases)
+}

--- a/mysql/Save_test.go
+++ b/mysql/Save_test.go
@@ -1,0 +1,250 @@
+package mysql
+
+import (
+	"database/sql/driver"
+	"errors"
+	"log/slog"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+)
+
+type SavePersonTime struct {
+	Id      int       `db:"column=id primarykey=yes table=Users"`
+	Name    string    `db:"column=name"`
+	Dtadded time.Time `db:"column=dtadded omit=yes"`
+	Status  int       `db:"column=status"`
+}
+
+// setupSaveTestMock sets up the mocks using sqlmock library
+func setupSaveTestMock(t *testing.T, sql string, params ...driver.Value) (*sqlmock.Sqlmock, *sqlmock.ExpectedExec) {
+	New("test/test", slog.Default())
+	var err error
+	var mock sqlmock.Sqlmock
+	DB.dbConnection, mock, err = sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	DB.connected = true
+	assert.NoError(t, err)
+	expectedExec := mock.ExpectExec(sql)
+	if len(params) > 0 {
+		expectedExec.WithArgs(params...)
+	}
+	return &mock, expectedExec
+}
+
+// TestSaveNormalInsert tests normal insert
+func TestSaveNormalInsert(t *testing.T) {
+	mock, expectedExec := setupSaveTestMock(t, `INSERT INTO Users(name,status) VALUES (X'54657374',31);`)
+	expectedExec.WillReturnResult(sqlmock.NewResult(1, 1))
+	entry := SavePersonTime{0, "Test", time.Now(), 31}
+	lastInsertedID, rowsAffected, err := DB.Save(entry, entry.Id)
+	assert.NoError(t, err)
+	assert.NoError(t, (*mock).ExpectationsWereMet())
+	assert.Equal(t, lastInsertedID, int64(1))
+	assert.Equal(t, rowsAffected, int64(1))
+}
+
+// TestSaveNormalUpdate tests normal update
+func TestSaveNormalUpdate(t *testing.T) {
+	mock, expectedExec := setupSaveTestMock(t, `UPDATE Users SET name=X'54657374',status=31 WHERE id=1;`)
+	expectedExec.WillReturnResult(sqlmock.NewResult(0, 1))
+	entry := SavePersonTime{1, "Test", time.Now(), 31}
+	lastInsertedID, rowsAffected, err := DB.Save(entry, entry.Id)
+	assert.NoError(t, err)
+	assert.NoError(t, (*mock).ExpectationsWereMet())
+	assert.Equal(t, lastInsertedID, int64(0))
+	assert.Equal(t, rowsAffected, int64(1))
+}
+
+// TestSaveNoColumn tests no column field struct
+func TestSaveNoColumn(t *testing.T) {
+	mock, expectedExec := setupSaveTestMock(t, `UPDATE Users SET name=X'54657374',status=31 WHERE id=1;`)
+	expectedExec.WillReturnResult(sqlmock.NewResult(1, 1))
+	type NoColumn struct {
+		Id      int       `db:"column=id primarykey=yes table=Users"`
+		Name    string    `db:"column="`
+		Dtadded time.Time `db:"column=dtadded omit=yes"`
+		Status  int       `db:"column=status"`
+	}
+	entry := NoColumn{1, "Test", time.Now(), 31}
+	_, _, err := DB.Save(entry, entry.Id)
+	assert.EqualError(t, err, "no column name specified for field Name")
+	assert.Error(t, (*mock).ExpectationsWereMet())
+
+	_, _, err = DB.Save(entry, 0)
+	assert.EqualError(t, err, "no column name specified for field Name")
+	assert.Error(t, (*mock).ExpectationsWereMet())
+}
+
+// TestSaveNoPKVUpdate tests no pkv in struct with update
+func TestSaveNoPKVUpdate(t *testing.T) {
+	mock, expectedExec := setupSaveTestMock(t, `UPDATE Users SET name=X'54657374',status=31 WHERE id=1;`)
+	expectedExec.WillReturnResult(sqlmock.NewResult(1, 1))
+	entry := struct {
+		Id      int       `db:"column=id table=Users"`
+		Name    string    `db:"column=name"`
+		Dtadded time.Time `db:"column=dtadded omit=yes"`
+		Status  int       `db:"column=status"`
+	}{1, "Test", time.Now(), 31}
+	lastInsertedID, rowsAffected, err := DB.Save(entry, entry.Id)
+	assert.EqualError(t, err, "no primary key set, unable to set a where clause")
+	assert.Error(t, (*mock).ExpectationsWereMet())
+	assert.Equal(t, lastInsertedID, int64(0))
+	assert.Equal(t, rowsAffected, int64(0))
+}
+
+// TestSaveEmptyStruct tests empty struct
+func TestSaveEmptyStruct(t *testing.T) {
+	mock, expectedExec := setupSaveTestMock(t, `UPDATE Users SET name=X'54657374',status=31 WHERE id=1;`)
+	expectedExec.WillReturnResult(sqlmock.NewResult(1, 1))
+	entry := struct{}{}
+	_, _, err := DB.Save(entry, 0)
+	assert.Error(t, err)
+	assert.Error(t, (*mock).ExpectationsWereMet())
+
+	_, _, err = DB.Save(entry, 1)
+	assert.Error(t, err)
+	assert.Error(t, (*mock).ExpectationsWereMet())
+}
+
+type GenericEntity struct {
+	Id     interface{} `db:"column=id primarykey=yes table=Users"`
+	Name   string      `db:"column=name"`
+	Status int         `db:"column=status"`
+}
+
+// TestSavePrimaryKeyTypes tests with zero pkv values of uint,uint8,uint16,uint32,uint64,int,int8,int16,int32,
+// int64,string,float32,float64,nil,struct,time.Time
+func TestSavePrimaryKeyTypes(t *testing.T) {
+	testCases := []struct {
+		name             string
+		primaryKeyValue  interface{}
+		expectedQuery    string
+		expectedIsInsert bool
+	}{
+		// Unsigned Integers
+		{"Uint Zero", uint(0), `INSERT INTO Users(name,status) VALUES (X'54657374',31);`, true},
+		{"Uint Non-Zero", uint(42), `UPDATE Users SET name=X'54657374',status=31 WHERE id=42;`, false},
+		{"Uint8 Zero", uint8(0), `INSERT INTO Users(name,status) VALUES (X'54657374',31);`, true},
+		{"Uint8 Non-Zero", uint8(255), `UPDATE Users SET name=X'54657374',status=31 WHERE id=255;`, false},
+		{"Uint16 Zero", uint16(0), `INSERT INTO Users(name,status) VALUES (X'54657374',31);`, true},
+		{"Uint16 Non-Zero", uint16(65535), `UPDATE Users SET name=X'54657374',status=31 WHERE id=65535;`, false},
+		{"Uint32 Zero", uint32(0), `INSERT INTO Users(name,status) VALUES (X'54657374',31);`, true},
+		{"Uint32 Non-Zero", uint32(4294967295), `UPDATE Users SET name=X'54657374',status=31 WHERE id=4294967295;`, false},
+		{"Uint64 Zero", uint64(0), `INSERT INTO Users(name,status) VALUES (X'54657374',31);`, true},
+		{"Uint64 Non-Zero", uint64(18446744073709551615), `UPDATE Users SET name=X'54657374',status=31 WHERE id=18446744073709551615;`, false},
+
+		// Signed Integers
+		{"Int Zero", 0, `INSERT INTO Users(name,status) VALUES (X'54657374',31);`, true},
+		{"Int Positive", 42, `UPDATE Users SET name=X'54657374',status=31 WHERE id=42;`, false},
+		{"Int Negative", -42, `UPDATE Users SET name=X'54657374',status=31 WHERE id=-42;`, false},
+		{"Int8 Zero", int8(0), `INSERT INTO Users(name,status) VALUES (X'54657374',31);`, true},
+		{"Int8 Positive", int8(127), `UPDATE Users SET name=X'54657374',status=31 WHERE id=127;`, false},
+		{"Int8 Negative", int8(-128), `UPDATE Users SET name=X'54657374',status=31 WHERE id=-128;`, false},
+		{"Int16 Zero", int16(0), `INSERT INTO Users(name,status) VALUES (X'54657374',31);`, true},
+		{"Int16 Positive", int16(32767), `UPDATE Users SET name=X'54657374',status=31 WHERE id=32767;`, false},
+		{"Int16 Negative", int16(-32768), `UPDATE Users SET name=X'54657374',status=31 WHERE id=-32768;`, false},
+		{"Int32 Zero", int32(0), `INSERT INTO Users(name,status) VALUES (X'54657374',31);`, true},
+		{"Int32 Positive", int32(2147483647), `UPDATE Users SET name=X'54657374',status=31 WHERE id=2147483647;`, false},
+		{"Int32 Negative", int32(-2147483648), `UPDATE Users SET name=X'54657374',status=31 WHERE id=-2147483648;`, false},
+		{"Int64 Zero", int64(0), `INSERT INTO Users(name,status) VALUES (X'54657374',31);`, true},
+		{"Int64 Positive", int64(9223372036854775807), `UPDATE Users SET name=X'54657374',status=31 WHERE id=9223372036854775807;`, false},
+		{"Int64 Negative", int64(-9223372036854775808), `UPDATE Users SET name=X'54657374',status=31 WHERE id=-9223372036854775808;`, false},
+
+		// Floating Point
+		{"Float32 Zero", float32(0), `INSERT INTO Users(name,status) VALUES (X'54657374',31);`, true},
+		{"Float32 Positive", float32(3.14), `UPDATE Users SET name=X'54657374',status=31 WHERE id=3.14;`, false},
+		{"Float32 Negative", float32(-3.14), `UPDATE Users SET name=X'54657374',status=31 WHERE id=-3.14;`, false},
+		{"Float64 Zero", float64(0), `INSERT INTO Users(name,status) VALUES (X'54657374',31);`, true},
+		{"Float64 Positive", float64(3.14159), `UPDATE Users SET name=X'54657374',status=31 WHERE id=3.14159;`, false},
+		{"Float64 Negative", float64(-3.14159), `UPDATE Users SET name=X'54657374',status=31 WHERE id=-3.14159;`, false},
+
+		// String
+		{"String Empty", "", `INSERT INTO Users(name,status) VALUES (X'54657374',31);`, true},
+		{"String Non-Empty", "42", `UPDATE Users SET name=X'54657374',status=31 WHERE id=42;`, false},
+	}
+
+	for _, tc := range testCases {
+
+		t.Run(tc.name, func(t *testing.T) {
+			// setup mock
+			mock, expectedExec := setupSaveTestMock(t, tc.expectedQuery)
+
+			// prepare test entry
+			entry := GenericEntity{
+				Id:     tc.primaryKeyValue,
+				Name:   "Test",
+				Status: 31,
+			}
+
+			// setup expected results
+			var expectedID int64
+			switch v := tc.primaryKeyValue.(type) {
+			case int:
+				expectedID = int64(v)
+			case int8:
+				expectedID = int64(v)
+			case int16:
+				expectedID = int64(v)
+			case int32:
+				expectedID = int64(v)
+			case int64:
+				expectedID = v
+			case uint:
+				expectedID = int64(v)
+			case uint8:
+				expectedID = int64(v)
+			case uint16:
+				expectedID = int64(v)
+			case uint32:
+				expectedID = int64(v)
+			case uint64:
+				expectedID = int64(v)
+			case float32:
+				expectedID = int64(v)
+			case float64:
+				expectedID = int64(v)
+			case string:
+				if v == "" {
+					expectedID = 0
+				} else {
+					expectedID, _ = strconv.ParseInt(v, 10, 64)
+				}
+			default:
+				t.Fatalf("Unsupported type: %T", tc.primaryKeyValue)
+			}
+			expectedExec.WillReturnResult(sqlmock.NewResult(expectedID, 1))
+
+			// save
+			lastInsertedID, rowsAffected, err := DB.Save(entry, entry.Id)
+			assert.NoError(t, err)
+			assert.NoError(t, (*mock).ExpectationsWereMet())
+
+			assert.Equal(t, expectedID, lastInsertedID, "Update should return the existing ID")
+			assert.Equal(t, int64(1), rowsAffected, "Should affect exactly one row")
+
+		})
+	}
+}
+
+// TestSaveInsertError tests with db specific insert error
+func TestSaveInsertError(t *testing.T) {
+	mock, expectedExec := setupSaveTestMock(t, `INSERT INTO Users(name,status) VALUES (X'54657374',31);`)
+	expectedExec.WillReturnError(errors.New("dummy error"))
+	entry := SavePersonTime{0, "Test", time.Now(), 31}
+	_, _, err := DB.Save(entry, entry.Id)
+	assert.EqualError(t, err, "dummy error")
+	assert.NoError(t, (*mock).ExpectationsWereMet())
+}
+
+// TestSaveUpdateError tests with db specific update error
+func TestSaveUpdateError(t *testing.T) {
+	mock, expectedExec := setupSaveTestMock(t, `UPDATE Users SET name=X'54657374',status=31 WHERE id=1;`)
+	expectedExec.WillReturnError(errors.New("dummy error"))
+	entry := SavePersonTime{1, "Test", time.Now(), 31}
+	_, _, err := DB.Save(entry, entry.Id)
+	assert.EqualError(t, err, "dummy error")
+	assert.NoError(t, (*mock).ExpectationsWereMet())
+}

--- a/mysql/Update.go
+++ b/mysql/Update.go
@@ -50,6 +50,8 @@ func (db *Database) Update(dbStructure any) (string, error) {
 					buildsql = buildsql + hexRepresentation(value.(string)) + ","
 				case "float32", "float64":
 					buildsql = buildsql + fmt.Sprintf("%v", value) + ","
+				case "bool":
+					buildsql = buildsql + fmt.Sprintf("%v", value) + ","
 				case "Time":
 					buildsql = buildsql + fmt.Sprintf("'%s'", value.(time.Time).Format("2006-01-02 15:04:05")) + ","
 				default:

--- a/mysql/Update.go
+++ b/mysql/Update.go
@@ -32,9 +32,12 @@ func (db *Database) Update(dbStructure any) (string, error) {
 
 			if dbStructureMap["primarykey"] == "yes" {
 				// l.INFO("Primary Key Found: %s", dbStructureMap["table"])
-				UpdateTable = dbStructureMap["table"]
 				UpdateColumn = dbStructureMap["column"]
 				UpdateValue = fmt.Sprintf("%v", value)
+			}
+
+			if dbStructureMap["table"] != "" {
+				UpdateTable = dbStructureMap["table"]
 			}
 
 			if dbStructureMap["omit"] != "yes" && dbStructureMap["primarykey"] != "yes" {
@@ -64,6 +67,10 @@ func (db *Database) Update(dbStructure any) (string, error) {
 
 	if buildsql == "" {
 		return "", fmt.Errorf("no non-primary key and non-omitted fields found in structure")
+	}
+
+	if UpdateColumn == "" {
+		return "", fmt.Errorf("no primary key set, unable to set a where clause")
 	}
 
 	buildsql = strings.TrimSuffix(buildsql, ",")

--- a/mysql/Update_test.go
+++ b/mysql/Update_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type UpdatePerson[StatusType uint | uint8 | uint16 | uint32 | uint64 | int | int8 | int16 | int32 | int64 | float32 | float64 | string] struct {
+type UpdatePerson[StatusType uint | uint8 | uint16 | uint32 | uint64 | int | int8 | int16 | int32 | int64 | float32 | float64 | string | bool] struct {
 	Id      int        `db:"column=id primarykey=yes table=Users"`
 	Name    string     `db:"column=name"`
 	Dtadded time.Time  `db:"column=dtadded omit=yes"`
@@ -20,7 +20,7 @@ type UpdatePersonTime struct {
 	Dtadded time.Time `db:"column=dtadded"`
 }
 
-func generateUpdatePerson[StatusType uint | uint8 | uint16 | uint32 | uint64 | int | int8 | int16 | int32 | int64 | float32 | float64 | string](value StatusType) UpdatePerson[StatusType] {
+func generateUpdatePerson[StatusType uint | uint8 | uint16 | uint32 | uint64 | int | int8 | int16 | int32 | int64 | float32 | float64 | string | bool](value StatusType) UpdatePerson[StatusType] {
 	return UpdatePerson[StatusType]{
 		0, "Test", time.Now(), value,
 	}
@@ -35,6 +35,11 @@ func generateUpdatePersonTime(id int) UpdatePersonTime {
 func testUpdateNumericalErrorValueHelper(t *testing.T, sql string, err error) {
 	assert.NoError(t, err)
 	assert.Equal(t, "UPDATE Users SET name=X'54657374',status=1 WHERE id=0;", sql)
+}
+
+func testUpdateBoolErrorValueHelper(t *testing.T, sql string, err error) {
+	assert.NoError(t, err)
+	assert.Equal(t, "UPDATE Users SET name=X'54657374',status=true WHERE id=0;", sql)
 }
 
 func testUpdateStringErrorValueHelper(t *testing.T, sql string, err error) {
@@ -74,6 +79,8 @@ func TestUpdate(t *testing.T) {
 	testUpdateNumericalErrorValueHelper(t, sql, err)
 	sql, err = DB.Update(generateUpdatePerson(float64(1)))
 	testUpdateNumericalErrorValueHelper(t, sql, err)
+	sql, err = DB.Update(generateUpdatePerson(true))
+	testUpdateBoolErrorValueHelper(t, sql, err)
 
 	sql, err = DB.Update(generateUpdatePerson("1"))
 	testUpdateStringErrorValueHelper(t, sql, err)

--- a/mysql/db.go
+++ b/mysql/db.go
@@ -1,77 +1,77 @@
 package mysql
 
 import (
-    "fmt"
-    "reflect"
-    "strings"
-    "unicode"
-    
-    _ "github.com/go-sql-driver/mysql"
+	"fmt"
+	"reflect"
+	"strings"
+	"unicode"
+
+	_ "github.com/go-sql-driver/mysql"
 )
 
 // decodeTags Turn a tag string into a map of key/value pairs
 func decodeTag(tag string) map[string]string {
-    
-    lastQuote := rune(0)
-    f := func(c rune) bool {
-        switch {
-        case c == lastQuote:
-            lastQuote = rune(0)
-            return false
-        case lastQuote != rune(0):
-            return false
-        case unicode.In(c, unicode.Quotation_Mark):
-            lastQuote = c
-            return false
-        default:
-            return unicode.IsSpace(c)
-            
-        }
-    }
-    
-    // splitting string by space but considering quoted section
-    items := strings.FieldsFunc(tag, f)
-    
-    // create and fill the map
-    m := make(map[string]string)
-    for _, item := range items {
-        x := strings.Split(item, "=")
-        m[x[0]] = x[1]
-    }
-    
-    // print the map
-    // for k, v := range m {
-    //    fmt.Printf("%s: %s\n", k, v)
-    // }
-    return m
+
+	lastQuote := rune(0)
+	f := func(c rune) bool {
+		switch {
+		case c == lastQuote:
+			lastQuote = rune(0)
+			return false
+		case lastQuote != rune(0):
+			return false
+		case unicode.In(c, unicode.Quotation_Mark):
+			lastQuote = c
+			return false
+		default:
+			return unicode.IsSpace(c)
+
+		}
+	}
+
+	// splitting string by space but considering quoted section
+	items := strings.FieldsFunc(tag, f)
+
+	// create and fill the map
+	m := make(map[string]string)
+	for _, item := range items {
+		x := strings.Split(item, "=")
+		m[x[0]] = x[1]
+	}
+
+	// print the map
+	// for k, v := range m {
+	//    fmt.Printf("%s: %s\n", k, v)
+	// }
+	return m
 }
 
 // HexRepresentation Convert a string to a hex representation
 func hexRepresentation(in string) string {
-    return "X'" + fmt.Sprintf("%x", in) + "'"
-    // return "'" + in + "'"
+	return "X'" + fmt.Sprintf("%x", in) + "'"
+	// return "'" + in + "'"
 }
 
 // getStructDetails Get the details of a struct
 func getStructDetails[T any](dbFieldName string) (string, any) {
-    
-    var st T
-    t := reflect.TypeOf(st)
-    
-    for i := 0; i < t.NumField(); i++ {
-        field := t.Field(i)
-        tag := field.Tag.Get("db")
-        dbStructureMap := decodeTag(tag)
-        // l.INFO("%d. %v (%v), tag: '%v'\n", i+1, field.Name, field.Type.Name(), tag)
-        // l.SPEW(field.Type)
-        
-        if dbStructureMap["column"] == dbFieldName {
-            if field.Type == reflect.TypeOf([]uint8{}) {
-                return field.Name, "[]uint8"
-            } else {
-                return field.Name, field.Type.Name()
-            }
-        }
-    }
-    return "", ""
+
+	var st T
+	t := reflect.TypeOf(st)
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		tag := field.Tag.Get("db")
+		dbStructureMap := decodeTag(tag)
+		// l.INFO("%d. %v (%v), tag: '%v'\n", i+1, field.Name, field.Type.Name(), tag)
+		// l.SPEW(field.Type)
+
+		if dbStructureMap["column"] == dbFieldName {
+			if field.Type == reflect.TypeOf([]uint8{}) {
+				return field.Name, "[]uint8"
+			} else {
+				return field.Name, field.Type.Name()
+			}
+		}
+	}
+	return "", ""
 }


### PR DESCRIPTION
- Added DB.Save() functionality
- Added unit tests (go-mock) and integration tests (using sqlite3) for DB.Save()
- Fixed the issue of Insert() ignoring table tag if private key was not mentioned. Helps in the use case of when the ID in the table is not AUTOINCREMENT and we want to insert the ID manually.
- Fixed QueryStruct and its variants not returning non-int64 values even though they should.
- Added other types support in QueryStruct
- Added bool support in Insert() and Update()
- Fixed issue with Update() reporting the wrong error of "table not found" when primary key was not set. Instead added separate error handling of when primary key was not found.